### PR TITLE
add 'connectionParams' in register()

### DIFF
--- a/src/Shift31/LaravelElasticsearch/LaravelElasticsearchServiceProvider.php
+++ b/src/Shift31/LaravelElasticsearch/LaravelElasticsearchServiceProvider.php
@@ -42,6 +42,10 @@ class LaravelElasticsearchServiceProvider extends ServiceProvider {
 				$connParams['hosts'] = isset($hosts) ? $hosts : array(
 					'localhost:9200'
 				);
+				
+				if(isset($connectionParams))
+					$connParams['connectionParams'] = $connectionParams;
+				
 				$connParams['logPath'] = isset($logPath) ? $logPath : storage_path() . '/logs/hostbase-elasticsearch-' . php_sapi_name() . '.log';
 				$connParams['logLevel'] = isset($logLevel) ? $logLevel : Logger::INFO;
 


### PR DESCRIPTION
I used connectionParams for my production server

And `app/config/elsaticsearch.php` : 

```
return array(

    // connexion à searchbox.io
    'hosts' => [
        'your_hosts'
    ],
    'connectionParams' => [
        'auth' => [
            'site',
            'xxxxxxxxxxxxxx',
            'Basic' 
        ]
    ]
);
```
