### PR TITLE
Update default config namespace name. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,11 @@ Laravel artisan command
 ```
 $ php artisan config:publish shift31/laravel-elasticsearch 
 ```
-
-Manually: Create [app/config/elasticsearch.php](src/config/elasticsearch.php), modifying the following contents 
-accordingly:
+You can always read config parameters with:
 ```php
-<?php
-
-return array(
-    'hosts' => array(
-                    'your.elasticsearch.server:9200'
-                    ),
-    'logPath' => 'path/to/your/elasticsearch/log',
-);
+\Config::get('shift31::elasticsearch');
 ```
-Note: The keys of this array should be named according the parameters supported by Elasticsearch\Client.
+Note: The keys of this array should be named according the parameters supported by [Elasticsearch\Client](https://github.com/elastic/elasticsearch-php/blob/0.4/src/Elasticsearch/Client.php).
 
 3. In the `'providers'` array in app/config/app.php, add `'Shift31\LaravelElasticsearch\ElasticsearchServiceProvider'`. 
 
@@ -77,11 +68,7 @@ $result = Es::search($searchParams);
 
 Default Configuration
 ---------------------
-If you return an empty array in the config file:
-
-`'hosts'` defaults to localhost:9200
-
-`'logPath'` defaults to `storage_path() . '/logs/elasticsearch.log'`
+If you return an empty array in the config file, Service provider [merges default config with custom config variables](https://github.com/shift31/laravel-elasticsearch/blob/master/src/Shift31/LaravelElasticsearch/ElasticsearchServiceProvider.php#L27).
 
 [Default config file](src/config/elasticsearch.php) which is publishing by artisan command.
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
         <testsuite name="unit">
             <directory suffix=".php">./tests/Unit</directory>
         </testsuite>
+        <testsuite name="integration">
+            <directory suffix=".php">./tests/Integration</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <blacklist>

--- a/src/Shift31/LaravelElasticsearch/ElasticsearchServiceProvider.php
+++ b/src/Shift31/LaravelElasticsearch/ElasticsearchServiceProvider.php
@@ -12,7 +12,7 @@ class ElasticsearchServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->package('shift31/laravel-elasticsearch');
+        $this->package('shift31/laravel-elasticsearch', 'shift31');
     }
 
     /**
@@ -21,7 +21,7 @@ class ElasticsearchServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('elasticsearch', function () {
-            $customConfig = $this->app->config->get('elasticsearch');
+            $customConfig = $this->app->config->get('shift31::elasticsearch');
             $defaultConfig = $this->loadDefaultConfig();
 
             return new Client(array_merge($defaultConfig, $customConfig));

--- a/tests/Integration/ElasticsearchServiceProviderIntegrationTest.php
+++ b/tests/Integration/ElasticsearchServiceProviderIntegrationTest.php
@@ -2,6 +2,7 @@
 namespace Shift31\LaravelElasticsearch\Tests\Integration;
 
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Config;
 use Shift31\LaravelElasticsearch\Facades\Es;
 
 class ElasticsearchServiceProviderIntegrationTest extends TestCase
@@ -12,6 +13,14 @@ class ElasticsearchServiceProviderIntegrationTest extends TestCase
         $result = Es::indices()->create($indexParams);
         $this->assertArrayHasKey('acknowledged', $result);
         $this->assertTrue($result['acknowledged']);
+    }
+
+    public function test_get_elasticsearch_config()
+    {
+        $config = Config::get('shift31::elasticsearch');
+        $this->assertArrayHasKey('hosts', $config);
+        $this->assertArrayHasKey('logPath', $config);
+        $this->assertArrayHasKey('logLevel', $config);
     }
 
     protected function getPackageProviders()

--- a/tests/Unit/ElasticsearchServiceProviderUnitTest.php
+++ b/tests/Unit/ElasticsearchServiceProviderUnitTest.php
@@ -24,7 +24,7 @@ class ElasticsearchServiceProviderUnitTest extends TestCase
         });
         $configMock = Mockery::mock('Illuminate\Config\Repository', function (MockInterface $m) use ($configPath) {
             $m->shouldReceive('package')
-                ->with('shift31/laravel-elasticsearch', $configPath, 'laravel-elasticsearch')
+                ->with('shift31/laravel-elasticsearch', $configPath, 'shift31')
                 ->once()
                 ->andReturnSelf();
         });
@@ -42,24 +42,25 @@ class ElasticsearchServiceProviderUnitTest extends TestCase
     {
         $configPath = $this->getSourcePath('config/elasticsearch.php');
         $configMock = Mockery::mock('Illuminate\Config\Repository', function (MockInterface $m) {
-            $m->shouldReceive('get')->with('elasticsearch')->andReturn([]);
+            $m->shouldReceive('get')->with('shift31::elasticsearch')->andReturn([]);
         });
         $filesMock = Mockery::mock('Illuminate\Filesystem\Filesystem', function (MockInterface $m) use ($configPath) {
             $m->shouldReceive('getRequire')
                 ->with($configPath)
                 ->once()->andReturn([]);
         });
-        $application = Mockery::mock('Illuminate\Foundation\Application', function (MockInterface $m) use ($configMock, $filesMock) {
-            $m->shouldReceive('booting')->once()->andReturnSelf();
-            $m->shouldReceive('offsetGet')->with('config')->andReturn($configMock);
-            $m->shouldReceive('offsetGet')->with('files')->andReturn($filesMock);
-            $m->shouldReceive('singleton')->with('elasticsearch',
-                Mockery::on(function ($closure) {
-                    $this->assertInstanceOf('Elasticsearch\Client', $closure());
+        $application = Mockery::mock('Illuminate\Foundation\Application',
+            function (MockInterface $m) use ($configMock, $filesMock) {
+                $m->shouldReceive('booting')->once()->andReturnSelf();
+                $m->shouldReceive('offsetGet')->with('config')->andReturn($configMock);
+                $m->shouldReceive('offsetGet')->with('files')->andReturn($filesMock);
+                $m->shouldReceive('singleton')->with('elasticsearch',
+                    Mockery::on(function ($closure) {
+                        $this->assertInstanceOf('Elasticsearch\Client', $closure());
 
-                    return true;
-                }))->once()->andReturnSelf();
-        });
+                        return true;
+                    }))->once()->andReturnSelf();
+            });
         $provider = new ElasticsearchServiceProvider($application);
         $this->assertNull($provider->register());
     }


### PR DESCRIPTION
Update default config namespace name. 
Add integration tests path in [phpunit.xml](https://github.com/shift31/laravel-elasticsearch/blob/master/phpunit.xml).
Update README file with how to publish config file.